### PR TITLE
Use blank value for "desc" option when sorting ratings

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -76,7 +76,7 @@ class UserController extends Controller
             ->toArray();
         $sortOptions = ['' => 'rated date', 'score' => 'score', 'sr' => 'star rating',
             'ranked_date' => 'ranked date'];
-        $sortDirectionOptions = ['desc' => 'desc', 'asc' => 'asc'];
+        $sortDirectionOptions = ['' => 'desc', 'asc' => 'asc'];
 
         return view('users.ratings', [
             'user' => $user,


### PR DESCRIPTION
This avoids "desc" appearing in the query string when no filters or sort options are selected.